### PR TITLE
Add web2py's cache decorator to the front page DB fetch action

### DIFF
--- a/controllers/default.py
+++ b/controllers/default.py
@@ -282,6 +282,7 @@ def checkImages(hashed, min_date, credentials, exclude_pk=None):
     return dict(exact_matches=exact_matches, neighbors=neighbors)
 
 
+@cache()
 def pull_latest(credentials):
     start_date = date.today()-timedelta(days=30)
     start_date = start_date.strftime("%Y-%m-%d")           


### PR DESCRIPTION
5 minutes cache.

This significantly speeds up *subsequent* loads of ITP's main page.

Closes #7